### PR TITLE
Add ability to set prophecies to the MockInjector container that the …

### DIFF
--- a/src/MockingContainerInterface.php
+++ b/src/MockingContainerInterface.php
@@ -26,4 +26,12 @@ interface MockingContainerInterface extends ContainerInterface
      * @return ObjectProphecy[]
      */
     public function getAllMocks();
+
+    /**
+     * Set a prophecy to be used by the injector rather than creating on demand.
+     * @param string $mockClassName
+     * @param ObjectProphecy $mock
+     * @return void
+     */
+    public function setMock(string $mockClassName, ObjectProphecy $mock);
 }

--- a/src/ProphecyMockingContainer.php
+++ b/src/ProphecyMockingContainer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bigcommerce\MockInjector;
 
 use Prophecy\Exception\Prediction\AggregateException;
@@ -11,6 +12,7 @@ class ProphecyMockingContainer implements MockingContainerInterface
      * @var Prophet
      */
     private $prophet;
+
     /**
      * Collection of mocks we've auto-created keyed by their FQCN
      * @var ObjectProphecy[]
@@ -43,7 +45,7 @@ class ProphecyMockingContainer implements MockingContainerInterface
      */
     public function get($id)
     {
-       return $this->createOrGetMock($id)->reveal();
+        return $this->createOrGetMock($id)->reveal();
     }
 
     /**
@@ -59,19 +61,25 @@ class ProphecyMockingContainer implements MockingContainerInterface
     /**
      * Fetch one of the mocks that was auto-created by the MockInjector to construct objects used in the current test,
      * so that you can set expectations or configure mock methods.
+     * Alternatively, will create and return a mock which the injector will use (useful for setting expectations
+     * on constructor behaviours prior to calling injector create)
      * @param string $mockClassName FQCN of the dependency we mocked
      * @return ObjectProphecy
-     * @throws \InvalidArgumentException
      */
     public function getMock($mockClassName)
     {
-        if (!isset($this->mocks[$mockClassName])) {
-            throw new \InvalidArgumentException(
-                "The MockInjector did not create a '$mockClassName' mock so it can not be retrieved."
-            );
-        }
+        return $this->createOrGetMock($mockClassName);
+    }
 
-        return $this->mocks[$mockClassName];
+    /**
+     * Set a prophecy to be used by the injector rather than creating on demand.
+     * @param string $mockClassName
+     * @param ObjectProphecy $mock
+     * @return void
+     */
+    public function setMock(string $mockClassName, ObjectProphecy $mock)
+    {
+        $this->mocks[$mockClassName] = $mock;
     }
 
     /**


### PR DESCRIPTION
…injector will use, allowing expectations on constructor behaviours.

#### What?

Add accessor to set prophecies to the MockInjector's container which the Injector will use for autoresolved mocks. This allows testers to set expectations on collaboration behaviour in object constructors.