### PR TITLE
Add compatibility with PHPUnit ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.0",
         "bigcommerce/injector": "@stable",
-        "phpunit/phpunit": "^6.0 || ^7.0"
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f426439ae8f3e6b0345dc2d49736759e",
+    "content-hash": "2931152321eb2c529aad30b9d3bd86e2",
     "packages": [
         {
             "name": "bigcommerce/injector",
@@ -13,6 +13,12 @@
                 "type": "git",
                 "url": "https://github.com/bigcommerce-labs/injector.git",
                 "reference": "8c6673265860478031c24faedb5ba0a5df5b2ee5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bigcommerce-labs/injector/zipball/8c6673265860478031c24faedb5ba0a5df5b2ee5",
+                "reference": "8c6673265860478031c24faedb5ba0a5df5b2ee5",
+                "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.1",
@@ -80,6 +86,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
@@ -1002,6 +1009,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2018-08-09T05:50:03+00:00"
         },
         {

--- a/src/AutoMockingTest.php
+++ b/src/AutoMockingTest.php
@@ -24,7 +24,7 @@ abstract class AutoMockingTest extends TestCase
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mockingContainerProphet = new Prophet();
@@ -46,7 +46,7 @@ abstract class AutoMockingTest extends TestCase
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->injector->checkPredictions();


### PR DESCRIPTION
#### What?

This adds compatibility with PHPUnit 8.x. The return type declarations are backwards-compatible with PHPUnit 6.x/7.x, but are required for PHPUnit 8.x.

#### Tickets / Documentation

- https://phpunit.de/announcements/phpunit-8.html
- https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration (see the note section about child return types)