### PR TITLE
Remove InjectorInterface type from test injector

### DIFF
--- a/src/AutoMockingTest.php
+++ b/src/AutoMockingTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Bigcommerce\MockInjector;
 
-use Bigcommerce\Injector\InjectorInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\MethodProphecy;
@@ -17,7 +16,7 @@ abstract class AutoMockingTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var InjectorInterface|MockInjector */
+    /** @var MockInjector */
     protected $injector;
 
     /** @var Prophet */


### PR DESCRIPTION
#### What?

Remove `InjectorInterface` from the declaration of `injector` in `AutoMockingTest`. It is causing phpstan validation failure in the shipping service. This is because it is strictly indicating this could be an `InjectorInterface`, which doesn't include the `getProphecy` method, frequently used in test cases.

#### Tickets / Documentation

Add links to any relevant issues and documentation.

- [CircleCI failure](https://app.circleci.com/pipelines/github/bigcommerce/shipping-service/2000/workflows/c78997c6-2833-43e9-85ea-17ac7afdda66/jobs/8016)

