### PR TITLE
PHPMNT-8 Add phpstan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,27 +4,17 @@ orbs:
   ci: bigcommerce/internal@volatile
   php: bigcommerce/internal-php@volatile
 
-jobs:
-  tests-unit:
+default_matrix: &default_matrix
+  matrix:
     parameters:
-      php-version:
-        type: string
-        default: "8.0"
-    executor:
-      name: php/php
-      php-version: << parameters.php-version >>
-    steps:
-      - ci/pre-setup
-      - php/composer-install:
-          composer_version: '--2'
-      - php/unit-phpunit:
-          configuration: 'phpunit.xml'
+      php-version: [ "8.0", "8.1", "8.2" ]
 
 workflows:
   version: 2
   full:
     jobs:
-      - tests-unit:
-          matrix:
-            parameters:
-              php-version: [ "8.0" ]
+      - php/phpunit-tests:
+          <<: *default_matrix
+      - php/static-analysis:
+          <<: *default_matrix
+          generate_ide_helper: false

--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -1,0 +1,96 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\AutoMockingTest\\:\\:createWithMocks\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/AutoMockingTest.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockInjector\\:\\:checkPredictions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: ../src/MockInjector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockInjector\\:\\:create\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/MockInjector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockInjector\\:\\:getAllMocks\\(\\) return type with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: ../src/MockInjector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockInjector\\:\\:getMock\\(\\) return type with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: ../src/MockInjector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockInjector\\:\\:getProphecy\\(\\) return type with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: ../src/MockInjector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockInjector\\:\\:invoke\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/MockInjector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockingContainerInterface\\:\\:checkPredictions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: ../src/MockingContainerInterface.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockingContainerInterface\\:\\:getAllMocks\\(\\) return type with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: ../src/MockingContainerInterface.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockingContainerInterface\\:\\:getMock\\(\\) return type with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: ../src/MockingContainerInterface.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\MockingContainerInterface\\:\\:setMock\\(\\) has parameter \\$mock with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy but does not specify its types\\: T$#"
+			count: 1
+			path: ../src/MockingContainerInterface.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\ProphecyMockingContainer\\:\\:checkPredictions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: ../src/ProphecyMockingContainer.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\ProphecyMockingContainer\\:\\:createOrGetMock\\(\\) return type with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: ../src/ProphecyMockingContainer.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\ProphecyMockingContainer\\:\\:getAllMocks\\(\\) return type with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: ../src/ProphecyMockingContainer.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\ProphecyMockingContainer\\:\\:getMock\\(\\) return type with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: ../src/ProphecyMockingContainer.php
+
+		-
+			message: "#^Method Bigcommerce\\\\MockInjector\\\\ProphecyMockingContainer\\:\\:setMock\\(\\) has parameter \\$mock with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy but does not specify its types\\: T$#"
+			count: 1
+			path: ../src/ProphecyMockingContainer.php
+
+		-
+			message: "#^Property Bigcommerce\\\\MockInjector\\\\ProphecyMockingContainer\\:\\:\\$mocks with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
+			count: 1
+			path: ../src/ProphecyMockingContainer.php
+
+		-
+			message: "#^Unable to resolve the template type T in call to method Prophecy\\\\Prophet\\:\\:prophesize\\(\\)$#"
+			count: 1
+			path: ../src/ProphecyMockingContainer.php
+
+		-
+			message: "#^Static property Bigcommerce\\\\MockInjector\\\\StaticArrayServiceCache\\:\\:\\$cache \\(Bigcommerce\\\\Injector\\\\Cache\\\\ArrayServiceCache\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: ../src/StaticArrayServiceCache.php

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "phpunit/phpunit": " ^9.0"
     },
     "require-dev": {
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32d8ef0ab11ecb0097dcca17e0ce00cf",
+    "content-hash": "8bc9753912bc68a38ea545f4908bd6c4",
     "packages": [
         {
             "name": "bigcommerce/injector",
@@ -2529,7 +2529,70 @@
             "time": "2022-06-03T18:03:27+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-04-19T13:47:27+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": [],

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+   level: 6
+   paths:
+     - ./src
+   bootstrapFiles:
+     - ./vendor/autoload.php
+includes:
+ - .phpstan/baseline.neon


### PR DESCRIPTION
## What/Why?
Check code with [phpstan](https://phpstan.org/)
By default, all current errors are suppressed.
We start from [level 6](https://phpstan.org/user-guide/rule-levels) and in the future may rise a bar.

## Testing
See circle.

## Deploy
This tool is used only in the CI environment and should not affect production.

## Useful links
PhpStan [documentation](https://phpstan.org/user-guide/getting-started)