### PR TITLE
PHPMNT-100 Support PHPUnit 9.5 or 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^8.1",
         "bigcommerce/injector": "^4.1",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": " ^10.0"
+        "phpunit/phpunit": "^9.5 || ^10.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10"

--- a/tests/AutoMockingTestTest.php
+++ b/tests/AutoMockingTestTest.php
@@ -15,7 +15,8 @@ class AutoMockingTestTest extends TestCase
 
         $riskyTest->runBare();
 
-        $this->assertSame(1, $riskyTest->numberOfAssertionsPerformed());
+        $this->assertFalse($riskyTest->isRisky());
+
     }
 
     public function testTestShouldBeRiskyWhenItHasNoAssertions(): void
@@ -24,6 +25,6 @@ class AutoMockingTestTest extends TestCase
 
         $riskyTest->runBare();
 
-        $this->assertSame(0, $riskyTest->numberOfAssertionsPerformed());
+        $this->assertTrue($riskyTest->isRisky());
     }
 }

--- a/tests/Dummy/DummyTest.php
+++ b/tests/Dummy/DummyTest.php
@@ -3,7 +3,9 @@ declare(strict_types = 1);
 
 namespace Tests\Dummy;
 
+use BadMethodCallException;
 use Bigcommerce\MockInjector\AutoMockingTest;
+use Exception;
 use Prophecy\Prophecy\ObjectProphecy;
 
 /**
@@ -32,5 +34,18 @@ class DummyTest extends AutoMockingTest
      */
     public function testWithoutAssertions() : void
     {
+    }
+
+    public function isRisky(): bool
+    {
+        if (is_callable([$this, 'numberOfAssertionsPerformed'])) {
+            return $this->numberOfAssertionsPerformed() === 0;
+        }
+
+        if (is_callable([$this, 'getNumAssertions'])) {
+            return $this->getNumAssertions() === 0;
+        }
+
+        throw new BadMethodCallException("Could not check the number of assertions performed");
     }
 }


### PR DESCRIPTION
#### What?

Reinstate support for PHPUnit 9.5 so we can use the latest injector in bcapp until its PHPUnit version is upgraded.

#### Tickets / Documentation

Add links to any relevant issues and documentation.

- [PHPMNT-100](https://bigcommercecloud.atlassian.net/browse/PHPMNT-100)



[PHPMNT-100]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ