### PR TITLE
Update bigcommerce/injector dependency to allow psr/container v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.3",
-        "bigcommerce/injector": "^4.1",
+        "bigcommerce/injector": "^5.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^11.0 || ^12.0"
     },

--- a/src/ProphecyMockingContainer.php
+++ b/src/ProphecyMockingContainer.php
@@ -53,7 +53,7 @@ class ProphecyMockingContainer implements MockingContainerInterface
      * @param string $id
      * @return bool
      */
-    public function has($id)
+    public function has($id): bool
     {
         return (class_exists($id) || interface_exists($id));
     }


### PR DESCRIPTION
#### What?
Update bigcommerce/injector dependency.

This also adds a backward-incompatible change by adding a return type to ProphecyMockingContainer::has(). That's required to support psr/container version 2.