### PR TITLE
PHPMNT-267 Add PHP 8.5 to CircleCI build/test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs_default: &jobs_default
     php-version: << matrix.php-version >>
   matrix:
     parameters:
-      php-version: [ "8.3", "8.4" ]
+      php-version: [ "8.3", "8.4", "8.5" ]
 
 
 workflows:


### PR DESCRIPTION
#### What?
Add PHP 8.5 to CircleCI build/test matrix. There are no deprecation warnings to fix or other updates to make, so this change will suffice to get CI running successfully on PHP 8.5