### PR TITLE
fix: add string type hints to has()/get() for psr/container 2.x compat on PHP 8.3

### DIFF
--- a/src/ProphecyMockingContainer.php
+++ b/src/ProphecyMockingContainer.php
@@ -43,7 +43,7 @@ class ProphecyMockingContainer implements MockingContainerInterface
      * @param string $id
      * @return mixed
      */
-    public function get($id)
+    public function get(string $id)
     {
         return $this->createOrGetMock($id)->reveal();
     }
@@ -53,7 +53,7 @@ class ProphecyMockingContainer implements MockingContainerInterface
      * @param string $id
      * @return bool
      */
-    public function has($id): bool
+    public function has(string $id): bool
     {
         return (class_exists($id) || interface_exists($id));
     }


### PR DESCRIPTION
## What/Why?
`ProphecyMockingContainer::has()` and `get()` were missing `string` type hints on their `$id` parameters. `psr/container 2.x` declares `ContainerInterface::has(string $id): bool`, and PHP raises a fatal error when an implementing class omits the type hint.

## Changes
- `ProphecyMockingContainer::has($id)` → `has(string $id)`
- `ProphecyMockingContainer::get($id)` → `get(string $id)`

## Rollout/Rollback
Merge / revert